### PR TITLE
Re-base #include directives to use paths returned by pkg-config

### DIFF
--- a/src/soundtouch_stubs.cc
+++ b/src/soundtouch_stubs.cc
@@ -38,8 +38,8 @@
 // Hack in order to have access to channels... (numChannels was only recently
 // introduced)
 #define protected public
-#include <soundtouch/BPMDetect.h>
-#include <soundtouch/SoundTouch.h>
+#include <BPMDetect.h>
+#include <SoundTouch.h>
 #undef protected
 
 using namespace soundtouch;


### PR DESCRIPTION
This was failing on systems where soundtouch include files are at non-standard place, like on homebrew.

E.g. `pkg-config --cflags soundtouch` on macos homebrew yields `-I/opt/homebrew/Celldar/sound-touch/version/include/soundtouch`

So, you only need say `#include <BPMDetect.h>` not `#include
<soundtouch/BPMDetect.h>`